### PR TITLE
Fix: remove `BasicCouncilVetoGovernor::cancel()` call in `BasicCouncilGovernor::cancel()`

### DIFF
--- a/src/BasicCouncilVetoGovernor.sol
+++ b/src/BasicCouncilVetoGovernor.sol
@@ -18,6 +18,9 @@ contract BasicCouncilVetoGovernor is
   GovernorVetoOverride,
   GovernorTimelockControl
 {
+  /// @notice Thrown when an operation is not supported
+  error CouncilVetoGovernor_OperationNotSupported();
+
   address public immutable COUNCIL;
 
   modifier onlyCouncil() {
@@ -88,15 +91,26 @@ contract BasicCouncilVetoGovernor is
     return super._executor();
   }
 
+  /**
+   * @notice Cancel is disabled.
+   * @notice By design, a proposal queued to the veto governor cannot be canceled. Proposal can
+   * only be rejected through veto votes, or through the veto guardian.
+   * @dev This function always reverts to prevent confusion between cancellation and veto
+   * operations, which serve different purposes in the governance flow.
+   */
   function cancel(
-    address[] memory targets,
-    uint256[] memory values,
-    bytes[] memory calldatas,
-    bytes32 descriptionHash
-  ) public override onlyCouncil returns (uint256) {
-    return super._cancel(targets, values, calldatas, descriptionHash);
+    address[] memory, /* targets */
+    uint256[] memory, /* values */
+    bytes[] memory, /* calldadtas */
+    bytes32 /* descriptionHash */
+  ) public pure override returns (uint256) {
+    revert CouncilVetoGovernor_OperationNotSupported();
   }
 
+  /// @inheritdoc GovernorTimelockControl
+  /// @dev We override this function to resolve ambiguity between inherited contracts.
+  /// @notice This internal function maintains the inheritance chain but should not be called
+  /// because the public cancel function is disabled.
   function _cancel(
     address[] memory targets,
     uint256[] memory values,

--- a/src/extensions/GovernorCouncilQueuing.sol
+++ b/src/extensions/GovernorCouncilQueuing.sol
@@ -120,15 +120,17 @@ abstract contract GovernorCouncilQueuing is Governor {
   }
 
   /**
-   * @dev Overridden version of the {Governor-_cancel} function to cancel the proposal if it has
-   * already
-   * been queued.
+   * @dev Overridden version of the {Governor-_cancel} function to cancel the proposal and clean up
+   * associated storage.
+   * @notice This function can only cancel proposals that are in the `Pending` state on the council
+   * governor. Once a proposal has been queued (forwarded to the veto governor), it cannot be
+   * canceled through this mechanism.
+   * @param targets Array of target addresses for the proposal calls
+   * @param values Array of values for the proposal calls
+   * @param calldatas Array of call data for the proposal calls
+   * @param descriptionHash Hash of the proposal description
+   * @return proposalId The ID of the proposal to be canceled
    */
-  // This function can reenter through the external call to the veto governor, but we assume the
-  // veto governor
-  // is trusted and
-  // well behaved (according to BasicCouncilVetoGovernor) and this will not happen.
-  // slither-disable-next-line reentrancy-no-eth
   function _cancel(
     address[] memory targets,
     uint256[] memory values,

--- a/src/extensions/GovernorCouncilQueuing.sol
+++ b/src/extensions/GovernorCouncilQueuing.sol
@@ -136,8 +136,7 @@ abstract contract GovernorCouncilQueuing is Governor {
     bytes32 descriptionHash
   ) internal virtual override returns (uint256) {
     uint256 proposalId = super._cancel(targets, values, calldatas, descriptionHash);
-
-    councilVetoGovernor.cancel(targets, values, calldatas, descriptionHash);
+    delete _proposalDescriptions[proposalId];
 
     return proposalId;
   }

--- a/test/BasicCouncilGovernor.t.sol
+++ b/test/BasicCouncilGovernor.t.sol
@@ -204,4 +204,42 @@ contract BasicCouncilGovernorSmokeTest is BasicCouncilGovernorTest {
     vm.prank(nonCouncilMember);
     councilGovernor.propose(targets, values, calldatas, description);
   }
+
+  function test_CancelsAPendingProposal() public {
+    vm.prank(councilMembers[0]);
+    uint256 proposalId = councilGovernor.propose(targets, values, calldatas, description);
+
+    skip(1);
+
+    vm.prank(councilMembers[0]);
+    councilGovernor.cancel(targets, values, calldatas, descriptionHash);
+
+    assertEq(uint8(councilGovernor.state(proposalId)), uint8(IGovernor.ProposalState.Canceled));
+  }
+
+  function test_RevertsIf_CancelsAForwardedProposal() public {
+    vm.prank(councilMembers[0]);
+    uint256 proposalId = councilGovernor.propose(targets, values, calldatas, description);
+    vm.warp(block.timestamp + councilGovernor.votingDelay() + 1);
+    for (uint256 i = 0; i < councilGovernor.quorum(0); i++) {
+      vm.prank(councilMembers[i]);
+      councilGovernor.castVote(proposalId, 1);
+    }
+    vm.warp(block.timestamp + councilGovernor.votingPeriod() + 1);
+
+    // Queue the proposal, which triggers the forwarding
+    councilGovernor.queue(targets, values, calldatas, descriptionHash);
+
+    // Assert the state is now `Queued` (which means "Forwarded" in this context)
+    assertEq(uint8(councilGovernor.state(proposalId)), uint8(IGovernor.ProposalState.Queued));
+    assertEq(uint8(vetoGovernor.state(proposalId)), uint8(IGovernor.ProposalState.Pending));
+
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        IGovernor.GovernorUnableToCancel.selector, proposalId, councilMembers[0]
+      )
+    );
+    vm.prank(councilMembers[0]);
+    councilGovernor.cancel(targets, values, calldatas, descriptionHash);
+  }
 }

--- a/test/BasicCouncilVetoGovernor.t.sol
+++ b/test/BasicCouncilVetoGovernor.t.sol
@@ -226,4 +226,18 @@ contract BasicCouncilVetoGovernorSmokeTest is BasicCouncilVetoGovernorTest {
     vm.prank(nonCouncilProposer);
     vetoGovernor.propose(targets, values, calldatas, "Invalid Proposal");
   }
+
+  function test_RevertIf_CancelAPendingProposal() public {
+    uint256 proposalId = _proposeAndForwardToVetoGovernor("Overridden");
+
+    assertEq(uint8(vetoGovernor.state(proposalId)), uint8(IGovernor.ProposalState.Pending));
+
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        BasicCouncilVetoGovernor.CouncilVetoGovernor_OperationNotSupported.selector
+      )
+    );
+    vm.prank(councilMembers[0]);
+    vetoGovernor.cancel(targets, values, calldatas, descriptionHash);
+  }
 }


### PR DESCRIPTION
Fixes #6 

- Removes `BasicCouncilVetoGovernor::cancel()` call in `BasicCouncilGovernor::cancel()`
- Adds proposal description clean up
- Adds natspec
- Adds `cancel` specific smoke tests for council and veto governor