### PR TITLE
Feature: add `GovernorAdmin`

### DIFF
--- a/script/DeployTest.s.sol
+++ b/script/DeployTest.s.sol
@@ -133,16 +133,16 @@ contract DeployOptimisticGovernance is Script, StdAssertions {
       .ConstructorParams(
       "BasicCouncilVetoGovernor",
       daoToken,
-      predictedCouncilGovernorAddress,
-      vetoGuardian,
-      MAIN_DAO_GOVERNOR, // The main DAO governor is the veto overrider
-      VETO_OVERRIDE_DURATION,
-      MAIN_DAO_GOVERNOR, // The main DAO governor is the governor admin
       1 hours, // initialVotingDelay
       1 days, // initialVotingPeriod
       0, // initialProposalThreshold
-      timelock
+      MAIN_DAO_GOVERNOR, // The main DAO governor is the veto overrider
+      VETO_OVERRIDE_DURATION,
+      timelock,
+      MAIN_DAO_GOVERNOR, // The main DAO governor is the governor admin
+      predictedCouncilGovernorAddress
     );
+
     // Deploy the Veto Governor, passing the pre-computed CouncilGovernor address
     vetoGovernor = new BasicCouncilVetoGovernor(vetoGovernorParams);
 

--- a/script/DeployTest.s.sol
+++ b/script/DeployTest.s.sol
@@ -129,16 +129,22 @@ contract DeployOptimisticGovernance is Script, StdAssertions {
     // Deploy Timelock, giving the *future* VetoGovernor the PROPOSER role
     timelock = new TimelockController(TIMELOCK_MIN_DELAY, proposers, executors, address(0));
 
-    // Deploy the Veto Governor, passing the pre-computed CouncilGovernor address
-    vetoGovernor = new BasicCouncilVetoGovernor(
+    BasicCouncilVetoGovernor.ConstructorParams memory vetoGovernorParams = BasicCouncilVetoGovernor
+      .ConstructorParams(
+      "BasicCouncilVetoGovernor",
       daoToken,
       predictedCouncilGovernorAddress,
       vetoGuardian,
       MAIN_DAO_GOVERNOR, // The main DAO governor is the veto overrider
-      MAIN_DAO_GOVERNOR, // The main DAO governor is the governor admin
       VETO_OVERRIDE_DURATION,
+      MAIN_DAO_GOVERNOR, // The main DAO governor is the governor admin
+      1 hours, // initialVotingDelay
+      1 days, // initialVotingPeriod
+      0, // initialProposalThreshold
       timelock
     );
+    // Deploy the Veto Governor, passing the pre-computed CouncilGovernor address
+    vetoGovernor = new BasicCouncilVetoGovernor(vetoGovernorParams);
 
     // Deploy the Council Governor, passing the now-deployed VetoGovernor address
     councilGovernor = new BasicCouncilGovernor(

--- a/script/DeployTest.s.sol
+++ b/script/DeployTest.s.sol
@@ -135,12 +135,20 @@ contract DeployOptimisticGovernance is Script, StdAssertions {
       predictedCouncilGovernorAddress,
       vetoGuardian,
       MAIN_DAO_GOVERNOR, // The main DAO governor is the veto overrider
+      MAIN_DAO_GOVERNOR, // The main DAO governor is the governor admin
       VETO_OVERRIDE_DURATION,
       timelock
     );
 
     // Deploy the Council Governor, passing the now-deployed VetoGovernor address
-    councilGovernor = new BasicCouncilGovernor(councilToken, vetoGovernor);
+    councilGovernor = new BasicCouncilGovernor(
+      councilToken,
+      vetoGovernor,
+      MAIN_DAO_GOVERNOR, // The main DAO governor is the governor admin
+      1 days,
+      1 weeks,
+      1
+    );
 
     // Sanity check: ensure predicted addresses match actual addresses
     assertEq(address(vetoGovernor), predictedVetoGovernorAddress);

--- a/script/DeployTest.s.sol
+++ b/script/DeployTest.s.sol
@@ -136,6 +136,7 @@ contract DeployOptimisticGovernance is Script, StdAssertions {
       1 hours, // initialVotingDelay
       1 days, // initialVotingPeriod
       0, // initialProposalThreshold
+      vetoGuardian,
       MAIN_DAO_GOVERNOR, // The main DAO governor is the veto overrider
       VETO_OVERRIDE_DURATION,
       timelock,

--- a/src/BasicCouncilGovernor.sol
+++ b/src/BasicCouncilGovernor.sol
@@ -9,30 +9,43 @@ import {IERC5805} from "@openzeppelin/contracts/interfaces/IERC5805.sol";
 import {GovernorCouncilQueuing} from "./extensions/GovernorCouncilQueuing.sol";
 import {GovernorSuperQuorum} from
   "@openzeppelin/contracts/governance/extensions/GovernorSuperQuorum.sol";
+import {GovernorSettings} from "@openzeppelin/contracts/governance/extensions/GovernorSettings.sol";
+import {GovernorAdmin} from "./extensions/GovernorAdmin.sol";
 
 contract BasicCouncilGovernor is
   Governor,
   GovernorVotes,
   GovernorCountingSimple,
   GovernorCouncilQueuing,
-  GovernorSuperQuorum
+  GovernorSuperQuorum,
+  GovernorSettings,
+  GovernorAdmin
 {
-  constructor(IERC5805 _token, IGovernor _councilVetoGovernor)
+  constructor(
+    IERC5805 _token,
+    IGovernor _councilVetoGovernor,
+    address _governorAdmin,
+    uint48 initialVotingDelay,
+    uint32 initialVotingPeriod,
+    uint256 initialProposalThreshold
+  )
     Governor("BasicCouncilGovernor")
     GovernorVotes(_token)
     GovernorCouncilQueuing(_councilVetoGovernor)
+    GovernorSettings(initialVotingDelay, initialVotingPeriod, initialProposalThreshold)
+    GovernorAdmin(_governorAdmin)
   {}
 
-  function votingDelay() public pure override returns (uint256) {
-    return 1 days;
+  function votingDelay() public view override(Governor, GovernorSettings) returns (uint256) {
+    return super.votingDelay();
   }
 
-  function votingPeriod() public pure override returns (uint256) {
-    return 1 weeks;
+  function votingPeriod() public view override(Governor, GovernorSettings) returns (uint256) {
+    return super.votingPeriod();
   }
 
-  function proposalThreshold() public pure override returns (uint256) {
-    return 1;
+  function proposalThreshold() public view override(Governor, GovernorSettings) returns (uint256) {
+    return super.proposalThreshold();
   }
 
   function quorum(uint256 /*timepoint*/ ) public pure override returns (uint256) {
@@ -50,6 +63,28 @@ contract BasicCouncilGovernor is
   /// forge-lint: disable-next-line(mixed-case-function)
   function CLOCK_MODE() public pure override(Governor, GovernorVotes) returns (string memory) {
     return "mode=timestamp";
+  }
+
+
+  function _checkGovernance() internal virtual override(Governor, GovernorAdmin) {
+    GovernorAdmin._checkGovernance();
+  }
+
+  function setVotingDelay(uint48 newVotingDelay) public virtual override onlyGovernance {
+    _setVotingDelay(newVotingDelay);
+  }
+
+  function setVotingPeriod(uint32 newVotingPeriod) public virtual override onlyGovernance {
+    _setVotingPeriod(newVotingPeriod);
+  }
+
+  function setProposalThreshold(uint256 newProposalThreshold)
+    public
+    virtual
+    override
+    onlyGovernance
+  {
+    _setProposalThreshold(newProposalThreshold);
   }
 
   function _cancel(

--- a/src/BasicCouncilVetoGovernor.sol
+++ b/src/BasicCouncilVetoGovernor.sol
@@ -7,6 +7,7 @@ import {GovernorVotes} from "@openzeppelin/contracts/governance/extensions/Gover
 import {GovernorSettings} from "@openzeppelin/contracts/governance/extensions/GovernorSettings.sol";
 import {IERC5805} from "@openzeppelin/contracts/interfaces/IERC5805.sol";
 import {GovernorVetoOverride} from "./extensions/GovernorVetoOverride.sol";
+import {GovernorVetoGuardian} from "./extensions/GovernorVetoGuardian.sol";
 import {GovernorAdmin} from "./extensions/GovernorAdmin.sol";
 import {
   GovernorTimelockControl,
@@ -35,6 +36,7 @@ contract BasicCouncilVetoGovernor is
    * @param votingDelay The delay before voting on a proposal begins.
    * @param votingPeriod The period of time voting will take place.
    * @param proposalThreshold The number of tokens needed to create a proposal.
+   * @param vetoGuardian The address authorized to veto proposals.
    * @param vetoOverrideRole The address authorized to override vetoed proposals.
    * @param vetoOverrideDuration Time window for overrides after proposal deadline.
    * @param timelock The timelock contract used for managing proposals.
@@ -47,6 +49,7 @@ contract BasicCouncilVetoGovernor is
     uint48 votingDelay;
     uint32 votingPeriod;
     uint256 proposalThreshold;
+    address vetoGuardian;
     address vetoOverrideRole;
     uint48 vetoOverrideDuration;
     TimelockController timelock;
@@ -62,6 +65,7 @@ contract BasicCouncilVetoGovernor is
   constructor(ConstructorParams memory _params)
     Governor(_params.name)
     GovernorVotes(_params.token)
+    GovernorVetoGuardian(_params.vetoGuardian)
     GovernorSettings(_params.votingDelay, _params.votingPeriod, _params.proposalThreshold)
     GovernorVetoOverride(_params.vetoOverrideRole, _params.vetoOverrideDuration)
     GovernorTimelockControl(_params.timelock)

--- a/src/BasicCouncilVetoGovernor.sol
+++ b/src/BasicCouncilVetoGovernor.sol
@@ -6,7 +6,7 @@ import {GovernorVetoCountingSimple} from "./extensions/GovernorVetoCountingSimpl
 import {GovernorVotes} from "@openzeppelin/contracts/governance/extensions/GovernorVotes.sol";
 import {IERC5805} from "@openzeppelin/contracts/interfaces/IERC5805.sol";
 import {GovernorVetoOverride} from "./extensions/GovernorVetoOverride.sol";
-import {GovernorVetoGuardian} from "./extensions/GovernorVetoGuardian.sol";
+import {GovernorAdmin} from "./extensions/GovernorAdmin.sol";
 import {
   GovernorTimelockControl,
   TimelockController
@@ -18,6 +18,7 @@ contract BasicCouncilVetoGovernor is
   GovernorVetoCountingSimple,
   GovernorVetoGuardian,
   GovernorVetoOverride,
+  GovernorAdmin,
   GovernorTimelockControl
 {
   /// @notice Thrown when an operation is not supported
@@ -35,6 +36,7 @@ contract BasicCouncilVetoGovernor is
     address _council,
     address _vetoGuardian,
     address _vetoOverrideRole,
+    address _governorAdmin,
     uint48 _vetoOverrideDuration,
     TimelockController _timelock
   )
@@ -43,6 +45,7 @@ contract BasicCouncilVetoGovernor is
     GovernorVetoGuardian(_vetoGuardian)
     GovernorVetoOverride(_vetoOverrideRole, _vetoOverrideDuration)
     GovernorTimelockControl(_timelock)
+    GovernorAdmin(_governorAdmin)
   {
     COUNCIL = _council;
   }
@@ -61,6 +64,10 @@ contract BasicCouncilVetoGovernor is
 
   function quorum(uint256 /*timepoint*/ ) public pure override returns (uint256) {
     return 10_000e18;
+  }
+
+  function _checkGovernance() internal virtual override(Governor, GovernorAdmin) {
+    GovernorAdmin._checkGovernance();
   }
 
   function propose(

--- a/src/BasicCouncilVetoGovernor.sol
+++ b/src/BasicCouncilVetoGovernor.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.30;
 import {Governor} from "@openzeppelin/contracts/governance/Governor.sol";
 import {GovernorVetoCountingSimple} from "./extensions/GovernorVetoCountingSimple.sol";
 import {GovernorVotes} from "@openzeppelin/contracts/governance/extensions/GovernorVotes.sol";
+import {GovernorSettings} from "@openzeppelin/contracts/governance/extensions/GovernorSettings.sol";
 import {IERC5805} from "@openzeppelin/contracts/interfaces/IERC5805.sol";
 import {GovernorVetoOverride} from "./extensions/GovernorVetoOverride.sol";
 import {GovernorAdmin} from "./extensions/GovernorAdmin.sol";
@@ -19,6 +20,7 @@ contract BasicCouncilVetoGovernor is
   GovernorVetoGuardian,
   GovernorVetoOverride,
   GovernorAdmin,
+  GovernorSettings,
   GovernorTimelockControl
 {
   /// @notice Thrown when an operation is not supported
@@ -26,40 +28,58 @@ contract BasicCouncilVetoGovernor is
 
   address public immutable COUNCIL;
 
+  /**
+   * @notice Data structure for deploying the `CouncilVetoGovernor`.
+   * @param name The name of the council veto governor.
+   * @param token The token used to veto governance proposals.
+   * @param votingDelay The delay before voting on a proposal begins.
+   * @param votingPeriod The period of time voting will take place.
+   * @param proposalThreshold The number of tokens needed to create a proposal.
+   * @param vetoOverrideRole The address authorized to override vetoed proposals.
+   * @param vetoOverrideDuration Time window for overrides after proposal deadline.
+   * @param timelock The timelock contract used for managing proposals.
+   * @param governorAdmin The address authorized to change governance parameters.
+   * @param council The address of the council governor.
+   */
+  struct ConstructorParams {
+    string name;
+    IERC5805 token;
+    uint48 votingDelay;
+    uint32 votingPeriod;
+    uint256 proposalThreshold;
+    address vetoOverrideRole;
+    uint48 vetoOverrideDuration;
+    TimelockController timelock;
+    address governorAdmin;
+    address council;
+  }
+
   modifier onlyCouncil() {
     require(msg.sender == COUNCIL, "Only council");
     _;
   }
 
-  constructor(
-    IERC5805 _token,
-    address _council,
-    address _vetoGuardian,
-    address _vetoOverrideRole,
-    address _governorAdmin,
-    uint48 _vetoOverrideDuration,
-    TimelockController _timelock
-  )
-    Governor("BasicVetoGovernor")
-    GovernorVotes(_token)
-    GovernorVetoGuardian(_vetoGuardian)
-    GovernorVetoOverride(_vetoOverrideRole, _vetoOverrideDuration)
-    GovernorTimelockControl(_timelock)
-    GovernorAdmin(_governorAdmin)
+  constructor(ConstructorParams memory _params)
+    Governor(_params.name)
+    GovernorVotes(_params.token)
+    GovernorSettings(_params.votingDelay, _params.votingPeriod, _params.proposalThreshold)
+    GovernorVetoOverride(_params.vetoOverrideRole, _params.vetoOverrideDuration)
+    GovernorTimelockControl(_params.timelock)
+    GovernorAdmin(_params.governorAdmin)
   {
-    COUNCIL = _council;
+    COUNCIL = _params.council;
   }
 
-  function votingDelay() public pure override returns (uint256) {
-    return 1 hours;
+  function votingDelay() public view override(Governor, GovernorSettings) returns (uint256) {
+    return super.votingDelay();
   }
 
-  function votingPeriod() public pure override returns (uint256) {
-    return 1 days;
+  function votingPeriod() public view override(Governor, GovernorSettings) returns (uint256) {
+    return super.votingPeriod();
   }
 
-  function proposalThreshold() public pure override returns (uint256) {
-    return 0;
+  function proposalThreshold() public view override(Governor, GovernorSettings) returns (uint256) {
+    return super.proposalThreshold();
   }
 
   function quorum(uint256 /*timepoint*/ ) public pure override returns (uint256) {

--- a/src/extensions/GovernorAdmin.sol
+++ b/src/extensions/GovernorAdmin.sol
@@ -9,7 +9,7 @@ import {Ownable} from "@openzeppelin/contracts/Access/Ownable.sol";
  * @notice Extension of {Governor} that restricts privileged governance actions to a desginated
  * admin.
  * @dev Overrides `Governor-_checkGovernance` so that only the admin can perform
- * governance-restricted operations. This allows an external main DAO to control critical governance
+ * governance-restricted operations. This allows an external address to control critical governance
  * parameters while preventing the council from manipulating these settings.
  */
 abstract contract GovernorAdmin is Governor, Ownable {

--- a/src/extensions/GovernorAdmin.sol
+++ b/src/extensions/GovernorAdmin.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.30;
+
+import {Governor} from "@openzeppelin/contracts/governance/Governor.sol";
+import {Ownable} from "@openzeppelin/contracts/Access/Ownable.sol";
+
+/**
+ * @title GovernorAdmin
+ * @notice Extension of {Governor} that restricts privileged governance actions to a desginated
+ * admin.
+ * @dev Overrides `Governor-_checkGovernance` so that only the admin can perform
+ * governance-restricted operations. This allows an external main DAO to control critical governance
+ * parameters while preventing the council from manipulating these settings.
+ */
+abstract contract GovernorAdmin is Governor, Ownable {
+
+  constructor(address _governorAdmin) Ownable(_governorAdmin) {}
+
+  /// @dev Ensures the caller is the degisnated admin before executing governance-retricted logic.
+  function _checkGovernance() internal virtual override {
+    _checkOwner();
+  }
+}

--- a/test/BasicCouncilGovernor.t.sol
+++ b/test/BasicCouncilGovernor.t.sol
@@ -72,14 +72,14 @@ abstract contract BasicCouncilGovernorTest is Test {
       .ConstructorParams(
       "BasicCouncilVetoGovernor",
       daoToken,
-      councilGovernorAddress,
-      deployer, // The main DAO governor is the veto overrider
-      4 days,
-      deployer, // The main DAO governor is the governor admin
       1 hours, // initialVotingDelay
       1 days, // initialVotingPeriod
       0, // initialProposalThreshold
-      timelock
+      deployer, // The main DAO governor is the veto overrider
+      4 days,
+      timelock,
+      deployer, // The main DAO governor is the governor admin
+      councilGovernorAddress
     );
 
     vm.prank(deployer);

--- a/test/BasicCouncilGovernor.t.sol
+++ b/test/BasicCouncilGovernor.t.sol
@@ -74,6 +74,7 @@ abstract contract BasicCouncilGovernorTest is Test {
       councilGovernorAddress,
       vetoGuardian,
       deployer, // Veto override role
+      deployer, // Governor admin
       4 days, // Veto override duration
       timelock
     );

--- a/test/BasicCouncilGovernor.t.sol
+++ b/test/BasicCouncilGovernor.t.sol
@@ -75,6 +75,7 @@ abstract contract BasicCouncilGovernorTest is Test {
       1 hours, // initialVotingDelay
       1 days, // initialVotingPeriod
       0, // initialProposalThreshold
+      vetoGuardian,
       deployer, // The main DAO governor is the veto overrider
       4 days,
       timelock,

--- a/test/BasicCouncilGovernor.t.sol
+++ b/test/BasicCouncilGovernor.t.sol
@@ -68,16 +68,22 @@ abstract contract BasicCouncilGovernorTest is Test {
     vm.prank(deployer);
     timelock = new TimelockController(TIMELOCK_MIN_DELAY, proposers, executors, address(0));
 
-    vm.prank(deployer);
-    vetoGovernor = new BasicCouncilVetoGovernor(
+    BasicCouncilVetoGovernor.ConstructorParams memory vetoGovernorParams = BasicCouncilVetoGovernor
+      .ConstructorParams(
+      "BasicCouncilVetoGovernor",
       daoToken,
       councilGovernorAddress,
-      vetoGuardian,
-      deployer, // Veto override role
-      deployer, // Governor admin
-      4 days, // Veto override duration
+      deployer, // The main DAO governor is the veto overrider
+      4 days,
+      deployer, // The main DAO governor is the governor admin
+      1 hours, // initialVotingDelay
+      1 days, // initialVotingPeriod
+      0, // initialProposalThreshold
       timelock
     );
+
+    vm.prank(deployer);
+    vetoGovernor = new BasicCouncilVetoGovernor(vetoGovernorParams);
 
     // 5. Deploy the Council Governor
     vm.prank(deployer);

--- a/test/BasicCouncilGovernor.t.sol
+++ b/test/BasicCouncilGovernor.t.sol
@@ -80,7 +80,8 @@ abstract contract BasicCouncilGovernorTest is Test {
 
     // 5. Deploy the Council Governor
     vm.prank(deployer);
-    councilGovernor = new BasicCouncilGovernor(councilToken, vetoGovernor);
+    councilGovernor =
+      new BasicCouncilGovernor(councilToken, vetoGovernor, deployer, 1 days, 1 weeks, 1);
 
     // 6. Prepare a sample proposal payload
     targets.push(address(target));

--- a/test/BasicCouncilVetoGovernor.t.sol
+++ b/test/BasicCouncilVetoGovernor.t.sol
@@ -88,6 +88,7 @@ abstract contract BasicCouncilVetoGovernorTest is Test {
       councilGovernorAddress,
       vetoGuardian,
       deployer, // Veto override role
+      deployer, // Governor admin
       4 days, // Veto override duration
       timelock
     );

--- a/test/BasicCouncilVetoGovernor.t.sol
+++ b/test/BasicCouncilVetoGovernor.t.sol
@@ -81,17 +81,23 @@ abstract contract BasicCouncilVetoGovernorTest is Test {
     vm.prank(deployer);
     timelock = new TimelockController(TIMELOCK_MIN_DELAY, proposers, executors, address(0));
 
-    // 6. Deploy the Veto Governor, passing it the pre-computed council address
-    vm.prank(deployer);
-    vetoGovernor = new BasicCouncilVetoGovernor(
+    BasicCouncilVetoGovernor.ConstructorParams memory vetoGovernorParams = BasicCouncilVetoGovernor
+      .ConstructorParams(
+      "BasicCouncilVetoGovernor",
       daoToken,
       councilGovernorAddress,
-      vetoGuardian,
-      deployer, // Veto override role
-      deployer, // Governor admin
-      4 days, // Veto override duration
+      deployer, // The main DAO governor is the veto overrider
+      4 days,
+      deployer, // The main DAO governor is the governor admin
+      1 hours, // initialVotingDelay
+      1 days, // initialVotingPeriod
+      0, // initialProposalThreshold
       timelock
     );
+
+    // 6. Deploy the Veto Governor, passing it the pre-computed council address
+    vm.prank(deployer);
+    vetoGovernor = new BasicCouncilVetoGovernor(vetoGovernorParams);
 
     // 7. Deploy the Council Governor
     vm.prank(deployer);

--- a/test/BasicCouncilVetoGovernor.t.sol
+++ b/test/BasicCouncilVetoGovernor.t.sol
@@ -85,14 +85,14 @@ abstract contract BasicCouncilVetoGovernorTest is Test {
       .ConstructorParams(
       "BasicCouncilVetoGovernor",
       daoToken,
-      councilGovernorAddress,
-      deployer, // The main DAO governor is the veto overrider
-      4 days,
-      deployer, // The main DAO governor is the governor admin
       1 hours, // initialVotingDelay
       1 days, // initialVotingPeriod
       0, // initialProposalThreshold
-      timelock
+      deployer, // The main DAO governor is the veto overrider
+      4 days,
+      timelock,
+      deployer, // The main DAO governor is the governor admin
+      councilGovernorAddress
     );
 
     // 6. Deploy the Veto Governor, passing it the pre-computed council address

--- a/test/BasicCouncilVetoGovernor.t.sol
+++ b/test/BasicCouncilVetoGovernor.t.sol
@@ -94,7 +94,8 @@ abstract contract BasicCouncilVetoGovernorTest is Test {
 
     // 7. Deploy the Council Governor
     vm.prank(deployer);
-    councilGovernor = new BasicCouncilGovernor(councilToken, vetoGovernor);
+    councilGovernor =
+      new BasicCouncilGovernor(councilToken, vetoGovernor, deployer, 1 days, 1 weeks, 1);
 
     // 8. Prepare a sample proposal payload
     targets.push(address(target));

--- a/test/BasicCouncilVetoGovernor.t.sol
+++ b/test/BasicCouncilVetoGovernor.t.sol
@@ -88,6 +88,7 @@ abstract contract BasicCouncilVetoGovernorTest is Test {
       1 hours, // initialVotingDelay
       1 days, // initialVotingPeriod
       0, // initialProposalThreshold
+      vetoGuardian,
       deployer, // The main DAO governor is the veto overrider
       4 days,
       timelock,

--- a/test/GovernorAdmin.t.sol
+++ b/test/GovernorAdmin.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {BasicCouncilGovernorTest} from "./BasicCouncilGovernor.t.sol";
+// import {GovernorAdmin} from "../src/extensions/GovernorAdmin.sol";
+import {GovernorSettings} from "@openzeppelin/contracts/governance/extensions/GovernorSettings.sol";
+import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
+import {Ownable} from "@openzeppelin/contracts/Access/Ownable.sol";
+
+contract GovernorAdminTest is BasicCouncilGovernorTest {
+  function _proposeForwardAndQueueToVetoGovernor(string memory _description)
+    internal
+    returns (uint256 proposalId, bytes32 _descriptionHash)
+  {
+    _descriptionHash = keccak256(bytes(_description));
+
+    vm.prank(councilMembers[0]);
+    uint256 councilProposalId = councilGovernor.propose(targets, values, calldatas, _description);
+
+    skip(councilGovernor.votingDelay() + 1);
+    for (uint256 i = 0; i < councilGovernor.quorum(0); i++) {
+      vm.prank(councilMembers[i]);
+      councilGovernor.castVote(councilProposalId, 1);
+    }
+    skip(councilGovernor.votingPeriod() + 1);
+
+    proposalId = councilGovernor.queue(targets, values, calldatas, _descriptionHash);
+
+    skip(vetoGovernor.proposalDeadline(proposalId) + 1);
+    vetoGovernor.queue(targets, values, calldatas, _descriptionHash);
+  }
+}
+
+contract VotingDelay is GovernorAdminTest {
+  function test_MainDaoSetsCouncilGovernorVotingDelay(uint48 newVotingDelay) public {
+    vm.prank(deployer);
+    councilGovernor.setVotingDelay(newVotingDelay);
+
+    assertEq(councilGovernor.votingDelay(), newVotingDelay);
+  }
+
+  function test_RevertIf_CouncilSetsVotingDelay(uint48 newVotingDelay) public {
+    targets[0] = address(councilGovernor);
+    calldatas[0] = abi.encodeCall(councilGovernor.setVotingDelay, newVotingDelay);
+
+    (uint256 proposalId, bytes32 _descriptionHash) =
+      _proposeForwardAndQueueToVetoGovernor("Set voting delay");
+
+    assertEq(uint8(vetoGovernor.state(proposalId)), uint8(IGovernor.ProposalState.Queued));
+    skip(timelock.getMinDelay() + 1);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(timelock))
+    );
+    councilGovernor.execute(targets, values, calldatas, _descriptionHash);
+  }
+}


### PR DESCRIPTION
Resolves #10 
Resolves #17

- add `GovernorAdmin.sol`
- install `GovernorAdmin` to `BasicCouncilGovernor` and `BasicCouncilVetoGovernor`
- install `GovernorSettings` to `BasicCouncilGovernor` and `BasicCouncilVetoGovernor`
- Since `BasicCouncilVetoGovernor` constructor param causes stack too deep, refactor to use `ConstructorParam` struct
- refactor scripts and tests
- add smoke tests