### PR TITLE
deploy script: refactor to use dependency injection

### DIFF
--- a/script/1_DeployAndMintCouncilERC20.s.sol
+++ b/script/1_DeployAndMintCouncilERC20.s.sol
@@ -3,15 +3,23 @@ pragma solidity ^0.8.30;
 
 import {Script} from "forge-std/Script.sol";
 import {BaseLogger} from "script/BaseLogger.sol";
-import {CouncilERC20DeployInput} from "script/DeployInput.sol";
+import {DeploymentConfigurationBase} from "script/DeploymentConfigurationBase.s.sol";
 import {CouncilERC20} from "src/CouncilERC20.sol";
 
-contract DeployAndMintCouncilERC20 is Script, BaseLogger, CouncilERC20DeployInput {
-  function run(address _deployer) public returns (CouncilERC20 councilToken) {
+contract DeployAndMintCouncilERC20 is Script, BaseLogger {
+  function run(
+    address _deployer,
+    DeploymentConfigurationBase.CouncilERC20DeploymentConfiguration memory _config
+  ) public returns (CouncilERC20 councilToken) {
     vm.startBroadcast(_deployer);
-    councilToken = new CouncilERC20(NAME, SYMBOL, ADMIN, MAX_TOKENS_PER_MEMBER);
-    for (uint256 _i = 0; _i < COUNCIL_MEMBERS_LENGTH(); _i++) {
-      councilToken.mint(COUNCIL_MEMBERS[_i], MAX_TOKENS_PER_MEMBER);
+    councilToken = new CouncilERC20(
+      _config.councilTokenName,
+      _config.councilTokenSymbol,
+      _config.councilTokenAdmin,
+      _config.maxTokensPerMember
+    );
+    for (uint256 _i = 0; _i < _config.councilMembersLength; _i++) {
+      councilToken.mint(_config.councilMembers[_i], _config.maxTokensPerMember);
     }
     vm.stopBroadcast();
 

--- a/script/2_DeployTimelock.s.sol
+++ b/script/2_DeployTimelock.s.sol
@@ -4,23 +4,28 @@ pragma solidity ^0.8.30;
 import {Script} from "forge-std/Script.sol";
 import {BaseLogger} from "script/BaseLogger.sol";
 import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
-import {TimelockDeployInput} from "script/DeployInput.sol";
+import {DeploymentConfigurationBase} from "script/DeploymentConfigurationBase.s.sol";
 
-contract DeployTimelock is Script, BaseLogger, TimelockDeployInput {
+contract DeployTimelock is Script, BaseLogger {
   function _computeVetoGovernorAddress(address _deployer) internal view returns (address) {
     uint256 _nextNonce = vm.getNonce(_deployer) + 1;
     return vm.computeCreateAddress(_deployer, _nextNonce);
   }
 
-  function run(address _deployer) public returns (TimelockController timelock) {
+  function run(
+    address _deployer,
+    DeploymentConfigurationBase.TimelockDeploymentConfiguration memory _config
+  ) public returns (TimelockController timelock) {
+    address _predictedVetoGovernorAddress = _computeVetoGovernorAddress(_deployer);
+
     vm.startBroadcast(_deployer);
 
     address[] memory _proposers = new address[](1);
     address[] memory _executors = new address[](1);
-    _proposers[0] = _computeVetoGovernorAddress(_deployer);
-    _executors[0] = _computeVetoGovernorAddress(_deployer);
+    _proposers[0] = _predictedVetoGovernorAddress;
+    _executors[0] = _predictedVetoGovernorAddress;
 
-    timelock = new TimelockController(TIMELOCK_MIN_DELAY, _proposers, _executors, address(0));
+    timelock = new TimelockController(_config.timelockMinDelay, _proposers, _executors, address(0));
 
     vm.stopBroadcast();
 

--- a/script/2_DeployTimelock.s.sol
+++ b/script/2_DeployTimelock.s.sol
@@ -7,25 +7,15 @@ import {TimelockController} from "@openzeppelin/contracts/governance/TimelockCon
 import {DeploymentConfigurationBase} from "script/DeploymentConfigurationBase.s.sol";
 
 contract DeployTimelock is Script, BaseLogger {
-  function _computeVetoGovernorAddress(address _deployer) internal view returns (address) {
-    uint256 _nextNonce = vm.getNonce(_deployer) + 1;
-    return vm.computeCreateAddress(_deployer, _nextNonce);
-  }
-
   function run(
     address _deployer,
     DeploymentConfigurationBase.TimelockDeploymentConfiguration memory _config
   ) public returns (TimelockController timelock) {
-    address _predictedVetoGovernorAddress = _computeVetoGovernorAddress(_deployer);
-
     vm.startBroadcast(_deployer);
 
-    address[] memory _proposers = new address[](1);
-    address[] memory _executors = new address[](1);
-    _proposers[0] = _predictedVetoGovernorAddress;
-    _executors[0] = _predictedVetoGovernorAddress;
-
-    timelock = new TimelockController(_config.timelockMinDelay, _proposers, _executors, address(0));
+    address[] memory _proposers = new address[](0);
+    address[] memory _executors = new address[](0);
+    timelock = new TimelockController(_config.timelockMinDelay, _proposers, _executors, _deployer);
 
     vm.stopBroadcast();
 

--- a/script/3_DeployVetoGovernor.s.sol
+++ b/script/3_DeployVetoGovernor.s.sol
@@ -38,6 +38,9 @@ contract DeployVetoGovernor is Script, BaseLogger {
     );
 
     vetoGovernor = new BasicCouncilVetoGovernor(_params);
+    _timelock.grantRole(_timelock.EXECUTOR_ROLE(), address(vetoGovernor));
+    _timelock.grantRole(_timelock.PROPOSER_ROLE(), address(vetoGovernor));
+    _timelock.renounceRole(_timelock.DEFAULT_ADMIN_ROLE(), _deployer);
 
     vm.stopBroadcast();
 

--- a/script/3_DeployVetoGovernor.s.sol
+++ b/script/3_DeployVetoGovernor.s.sol
@@ -4,33 +4,36 @@ pragma solidity ^0.8.30;
 import {Script} from "forge-std/Script.sol";
 import {BaseLogger} from "script/BaseLogger.sol";
 import {BasicCouncilVetoGovernor} from "src/BasicCouncilVetoGovernor.sol";
-import {VetoGovernorDeployInput} from "script/DeployInput.sol";
+import {DeploymentConfigurationBase} from "script/DeploymentConfigurationBase.s.sol";
 import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
 
-contract DeployVetoGovernor is Script, BaseLogger, VetoGovernorDeployInput {
+contract DeployVetoGovernor is Script, BaseLogger {
   function _computeCouncilGovernorAddress(address _deployer) internal view returns (address) {
     uint256 _nextNonce = vm.getNonce(_deployer) + 1;
     return vm.computeCreateAddress(_deployer, _nextNonce);
   }
 
-  function run(address _deployer, TimelockController _timelock)
-    public
-    returns (BasicCouncilVetoGovernor vetoGovernor)
-  {
+  function run(
+    address _deployer,
+    TimelockController _timelock,
+    DeploymentConfigurationBase.VetoGovernorDeploymentConfiguration memory _config
+  ) public returns (BasicCouncilVetoGovernor vetoGovernor) {
+    address _predictedCouncilGovernorAddress = _computeCouncilGovernorAddress(_deployer);
+
     vm.startBroadcast(_deployer);
 
-
-    BasicCouncilVetoGovernor.ConstructorParams memory _params = BasicCouncilVetoGovernor.ConstructorParams(
-      VETO_GOVERNOR_NAME,
-      MAIN_DAO_TOKEN,
-      INITIAL_VETO_GOVERNOR_VOTING_DELAY,
-      INITIAL_VETO_GOVERNOR_VOTING_PERIOD,
-      INITIAL_VETO_GOVERNOR_PROPOSAL_THRESHOLD,
-      VETO_OVERRIDE_ROLE,
-      VETO_OVERRIDE_DURATION,
-      VETO_GUARDIAN,
+    BasicCouncilVetoGovernor.ConstructorParams memory _params = BasicCouncilVetoGovernor
+      .ConstructorParams(
+      _config.vetoGovernorName,
+      _config.mainDaoToken,
+      _config.vetoGovernorInitialVotingDelay,
+      _config.vetoGovernorInitialVotingPeriod,
+      _config.vetoGovernorInitialProposalThreshold,
+      _config.vetoOverrideRole,
+      _config.vetoOverrideDuration,
+      _config.vetoGuardian,
       TimelockController(_timelock),
-      GOVERNOR_ADMIN,
+      _config.vetoGovernorAdmin,
       _computeCouncilGovernorAddress(_deployer)
     );
 

--- a/script/4_DeployCouncilGovernor.s.sol
+++ b/script/4_DeployCouncilGovernor.s.sol
@@ -8,24 +8,25 @@ import {BaseLogger} from "script/BaseLogger.sol";
 import {BasicCouncilGovernor} from "src/BasicCouncilGovernor.sol";
 import {BasicCouncilVetoGovernor} from "src/BasicCouncilVetoGovernor.sol";
 import {CouncilERC20} from "src/CouncilERC20.sol";
-import {CouncilGovernorDeployInput} from "script/DeployInput.sol";
+import {DeploymentConfigurationBase} from "script/DeploymentConfigurationBase.s.sol";
 import {IGovernor} from "@openzeppelin/contracts/governance/Governor.sol";
 
-contract DeployCouncilGovernor is Script, BaseLogger, CouncilGovernorDeployInput {
+contract DeployCouncilGovernor is Script, BaseLogger {
   function run(
     address _deployer,
     CouncilERC20 _councilToken,
-    BasicCouncilVetoGovernor _vetoGovernor
+    BasicCouncilVetoGovernor _vetoGovernor,
+    DeploymentConfigurationBase.CouncilGovernorDeploymentConfiguration memory _config
   ) public returns (BasicCouncilGovernor councilGovernor) {
     vm.startBroadcast(_deployer);
 
     councilGovernor = new BasicCouncilGovernor(
       IERC5805(_councilToken),
       IGovernor(_vetoGovernor),
-      GOVERNOR_ADMIN,
-      INITIAL_COUNCIL_GOVERNOR_VOTING_DELAY,
-      INITIAL_COUNCIL_GOVERNOR_VOTING_PERIOD,
-      INITIAL_COUNCIL_GOVERNOR_PROPOSAL_THRESHOLD
+      _config.councilGovernorAdmin,
+      _config.councilGovernorInitialVotingDelay,
+      _config.councilGovernorInitialVotingPeriod,
+      _config.councilGovernorInitialProposalThreshold
     );
 
     vm.stopBroadcast();

--- a/script/DeploymentConfigurationBase.s.sol
+++ b/script/DeploymentConfigurationBase.s.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC5805} from "@openzeppelin/contracts/interfaces/IERC5805.sol";
+
+abstract contract DeploymentConfigurationBase {
+  struct BaseDeploymentConfiguration {
+    address mainDaoGovernor;
+    IERC5805 mainDaoToken;
+    address governorAdmin;
+  }
+
+  struct CouncilERC20DeploymentConfiguration {
+    string councilTokenName;
+    string councilTokenSymbol;
+    address councilTokenAdmin;
+    uint256 maxTokensPerMember;
+    address[] councilMembers;
+    uint256 councilMembersLength;
+  }
+
+  struct TimelockDeploymentConfiguration {
+    uint256 timelockMinDelay;
+  }
+
+  struct VetoGovernorDeploymentConfiguration {
+    string vetoGovernorName;
+    IERC5805 mainDaoToken;
+    uint48 vetoGovernorInitialVotingDelay;
+    uint32 vetoGovernorInitialVotingPeriod;
+    uint256 vetoGovernorInitialProposalThreshold;
+    address vetoOverrideRole;
+    uint48 vetoOverrideDuration;
+    address vetoGuardian;
+    address vetoGovernorAdmin;
+  }
+
+  struct CouncilGovernorDeploymentConfiguration {
+    string councilGovernorName;
+    uint48 councilGovernorInitialVotingDelay;
+    uint32 councilGovernorInitialVotingPeriod;
+    uint256 councilGovernorInitialProposalThreshold;
+    address councilGovernorAdmin;
+  }
+
+  function _getBaseDeploymentConfiguration()
+    public
+    view
+    virtual
+    returns (BaseDeploymentConfiguration memory);
+
+  function _getCouncilERC20DeploymentConfiguration()
+    public
+    view
+    virtual
+    returns (CouncilERC20DeploymentConfiguration memory)
+  {}
+
+  function _getTimelockDeploymentConfiguration()
+    public
+    view
+    virtual
+    returns (TimelockDeploymentConfiguration memory)
+  {}
+
+  function _getVetoGovernorDeploymentConfiguration()
+    public
+    view
+    virtual
+    returns (VetoGovernorDeploymentConfiguration memory)
+  {}
+
+  function _getCouncilGovernorDeploymentConfiguration()
+    public
+    view
+    virtual
+    returns (CouncilGovernorDeploymentConfiguration memory)
+  {}
+}

--- a/script/DeploymentConfigurationLocal.s.sol
+++ b/script/DeploymentConfigurationLocal.s.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DeploymentConfigurationBase} from "script/DeploymentConfigurationBase.s.sol";
+import {DeploymentInputLocal} from "script/DeploymentInputLocal.sol";
+
+contract DeploymentConfigurationLocal is DeploymentConfigurationBase, DeploymentInputLocal {
+  function _getBaseDeploymentConfiguration()
+    public
+    view
+    override
+    returns (BaseDeploymentConfiguration memory)
+  {
+    return BaseDeploymentConfiguration({
+      mainDaoGovernor: MAIN_DAO_GOVERNOR,
+      mainDaoToken: MAIN_DAO_TOKEN,
+      governorAdmin: GOVERNOR_ADMIN
+    });
+  }
+
+  function _getCouncilERC20DeploymentConfiguration()
+    public
+    view
+    override
+    returns (CouncilERC20DeploymentConfiguration memory)
+  {
+    return CouncilERC20DeploymentConfiguration({
+      councilTokenName: COUNCIL_TOKEN_NAME,
+      councilTokenSymbol: COUNCIL_TOKEN_SYMBOL,
+      councilTokenAdmin: COUNCIL_TOKEN_ADMIN,
+      maxTokensPerMember: MAX_TOKENS_PER_MEMBER,
+      councilMembers: COUNCIL_MEMBERS,
+      councilMembersLength: COUNCIL_MEMBERS_LENGTH()
+    });
+  }
+
+  function _getTimelockDeploymentConfiguration()
+    public
+    view
+    override
+    returns (TimelockDeploymentConfiguration memory)
+  {
+    return TimelockDeploymentConfiguration({timelockMinDelay: TIMELOCK_MIN_DELAY});
+  }
+
+  function _getVetoGovernorDeploymentConfiguration()
+    public
+    view
+    override
+    returns (VetoGovernorDeploymentConfiguration memory)
+  {
+    BaseDeploymentConfiguration memory _baseConfig = _getBaseDeploymentConfiguration();
+    return VetoGovernorDeploymentConfiguration({
+      vetoGovernorName: VETO_GOVERNOR_NAME,
+      mainDaoToken: _baseConfig.mainDaoToken,
+      vetoGovernorInitialVotingDelay: VETO_GOVERNOR_INITIAL_VOTING_DELAY,
+      vetoGovernorInitialVotingPeriod: VETO_GOVERNOR_INITIAL_VOTING_PERIOD,
+      vetoGovernorInitialProposalThreshold: VETO_GOVERNOR_INITIAL_PROPOSAL_THRESHOLD,
+      vetoOverrideRole: VETO_OVERRIDE_ROLE,
+      vetoOverrideDuration: VETO_OVERRIDE_DURATION,
+      vetoGuardian: VETO_GUARDIAN,
+      vetoGovernorAdmin: _baseConfig.governorAdmin
+    });
+  }
+
+  function _getCouncilGovernorDeploymentConfiguration()
+    public
+    view
+    override
+    returns (CouncilGovernorDeploymentConfiguration memory)
+  {
+    BaseDeploymentConfiguration memory _baseConfig = _getBaseDeploymentConfiguration();
+    return CouncilGovernorDeploymentConfiguration({
+      councilGovernorName: COUNCIL_GOVERNOR_NAME,
+      councilGovernorInitialVotingDelay: COUNCIL_GOVERNOR_INITIAL_VOTING_DELAY,
+      councilGovernorInitialVotingPeriod: COUNCIL_GOVERNOR_INITIAL_VOTING_PERIOD,
+      councilGovernorInitialProposalThreshold: COUNCIL_GOVERNOR_INITIAL_PROPOSAL_THRESHOLD,
+      councilGovernorAdmin: _baseConfig.governorAdmin
+    });
+  }
+}

--- a/script/DeploymentInputLocal.sol
+++ b/script/DeploymentInputLocal.sol
@@ -3,22 +3,20 @@ pragma solidity ^0.8.30;
 
 import {IERC5805} from "@openzeppelin/contracts/interfaces/IERC5805.sol";
 
-contract OptimisticGovernanceDeployInput {
+contract DeploymentInputLocal {
   // Address that controls council membership
   address public constant MAIN_DAO_GOVERNOR = 0x1111111111111111111111111111111111111111;
   // DAO token used by the veto governor for vote weight (placeholder)
   IERC5805 public constant MAIN_DAO_TOKEN = IERC5805(0x2222222222222222222222222222222222222222);
   // Admin account allowed to adjust governor settings (placeholder)
   address public constant GOVERNOR_ADMIN = 0x3333333333333333333333333333333333333333;
-}
 
-contract CouncilERC20DeployInput is OptimisticGovernanceDeployInput {
   // Council token name
-  string public constant NAME = "Optimistic Council";
+  string public constant COUNCIL_TOKEN_NAME = "Optimistic Council";
   // Council token symbol
-  string public constant SYMBOL = "OC";
+  string public constant COUNCIL_TOKEN_SYMBOL = "OC";
   // Council token admin
-  address public constant ADMIN = MAIN_DAO_GOVERNOR;
+  address public constant COUNCIL_TOKEN_ADMIN = MAIN_DAO_GOVERNOR;
   // Max tokens per council member needed to create a proposal
   uint256 public constant MAX_TOKENS_PER_MEMBER = 1;
   // Initial council membership roster used in scripts/tests
@@ -32,40 +30,34 @@ contract CouncilERC20DeployInput is OptimisticGovernanceDeployInput {
     0xCAb91b447839E9598f4Cf73baEB475D8d9De1aC5
   ];
 
-  function COUNCIL_MEMBERS_LENGTH() public pure returns (uint256) {
+  function COUNCIL_MEMBERS_LENGTH() public view returns (uint256) {
     return COUNCIL_MEMBERS.length;
   }
-}
 
-contract TimelockDeployInput {
   // Delay enforced by the veto-governor timelock before execution
   uint256 public constant TIMELOCK_MIN_DELAY = 1 days;
-}
 
-contract VetoGovernorDeployInput is OptimisticGovernanceDeployInput {
   // Veto governor name
   string public constant VETO_GOVERNOR_NAME = "BasicCouncilVetoGovernor";
   // Veto governor voting delay
-  uint48 public constant INITIAL_VETO_GOVERNOR_VOTING_DELAY = 1 hours;
+  uint48 public constant VETO_GOVERNOR_INITIAL_VOTING_DELAY = 1 hours;
   // Veto governor voting period
-  uint32 public constant INITIAL_VETO_GOVERNOR_VOTING_PERIOD = 1 days;
+  uint32 public constant VETO_GOVERNOR_INITIAL_VOTING_PERIOD = 1 days;
   // Veto governor proposal threshold
-  uint256 public constant INITIAL_VETO_GOVERNOR_PROPOSAL_THRESHOLD = 0;
+  uint256 public constant VETO_GOVERNOR_INITIAL_PROPOSAL_THRESHOLD = 0;
   // Veto governor override role
   address public constant VETO_OVERRIDE_ROLE = MAIN_DAO_GOVERNOR;
   // Veto governor override duration
   uint48 public constant VETO_OVERRIDE_DURATION = 4 days;
   // Veto governor veto guardian
   address public VETO_GUARDIAN;
-}
 
-contract CouncilGovernorDeployInput is OptimisticGovernanceDeployInput {
   // Council governor name
   string public constant COUNCIL_GOVERNOR_NAME = "BasicCouncilGovernor";
   // Council governor voting delay
-  uint48 public constant INITIAL_COUNCIL_GOVERNOR_VOTING_DELAY = 1 days;
+  uint48 public constant COUNCIL_GOVERNOR_INITIAL_VOTING_DELAY = 1 days;
   // Council governor voting period
-  uint32 public constant INITIAL_COUNCIL_GOVERNOR_VOTING_PERIOD = 1 weeks;
+  uint32 public constant COUNCIL_GOVERNOR_INITIAL_VOTING_PERIOD = 1 weeks;
   // Council governor proposal threshold
-  uint256 public constant INITIAL_COUNCIL_GOVERNOR_PROPOSAL_THRESHOLD = 1;
+  uint256 public constant COUNCIL_GOVERNOR_INITIAL_PROPOSAL_THRESHOLD = 1;
 }

--- a/test/OptimisticGovernanceDeployment.integration.t.sol
+++ b/test/OptimisticGovernanceDeployment.integration.t.sol
@@ -15,13 +15,8 @@ import {DeployAndMintCouncilERC20} from "script/1_DeployAndMintCouncilERC20.s.so
 import {DeployTimelock} from "script/2_DeployTimelock.s.sol";
 import {DeployVetoGovernor} from "script/3_DeployVetoGovernor.s.sol";
 import {DeployCouncilGovernor} from "script/4_DeployCouncilGovernor.s.sol";
-import {
-  OptimisticGovernanceDeployInput,
-  CouncilERC20DeployInput,
-  TimelockDeployInput,
-  VetoGovernorDeployInput,
-  CouncilGovernorDeployInput
-} from "script/DeployInput.sol";
+import {DeploymentConfigurationLocal} from "script/DeploymentConfigurationLocal.s.sol";
+import {DeploymentInputLocal} from "script/DeploymentInputLocal.sol";
 
 /// @title Integration test for the Optimistic Governance deployment
 /// @notice This test exercises the entire deployment flow with verification after each phase.
@@ -32,22 +27,19 @@ contract OptimisticGovernanceDeployment is Test {
   BasicCouncilVetoGovernor public vetoGovernor;
   BasicCouncilGovernor public councilGovernor;
 
-  OptimisticGovernanceDeployInput baseInput;
-  CouncilERC20DeployInput councilERC20Input;
-  TimelockDeployInput timelockInput;
-  CouncilGovernorDeployInput councilInput;
-  VetoGovernorDeployInput vetoInput;
+  DeploymentInputLocal input;
+  DeploymentConfigurationLocal config;
+  address deployer;
 
   function setUp() public {
     string memory _rpcUrl = vm.rpcUrl("mainnet");
     uint256 _forkBlock = 23_810_240;
     vm.createSelectFork(_rpcUrl, _forkBlock);
 
-    baseInput = new OptimisticGovernanceDeployInput();
-    councilERC20Input = new CouncilERC20DeployInput();
-    timelockInput = new TimelockDeployInput();
-    councilInput = new CouncilGovernorDeployInput();
-    vetoInput = new VetoGovernorDeployInput();
+    input = new DeploymentInputLocal();
+    config = new DeploymentConfigurationLocal();
+
+    deployer = input.MAIN_DAO_GOVERNOR();
   }
 
   /*///////////////////////////////////////////////////////////////
@@ -74,27 +66,32 @@ contract OptimisticGovernanceDeployment is Test {
 
   function _step1_deployCouncilTokenAndMint() internal {
     require(address(councilToken) == address(0), "Council token already deployed");
+    DeploymentConfigurationLocal.CouncilERC20DeploymentConfiguration memory _config =
+      config._getCouncilERC20DeploymentConfiguration();
 
     DeployAndMintCouncilERC20 _script = new DeployAndMintCouncilERC20();
     _script.setLoggingSilenced(true);
-    councilToken = _script.run(baseInput.MAIN_DAO_GOVERNOR());
+    councilToken = _script.run(deployer, _config);
   }
 
   function _step2_deployTimelock() internal {
     require(address(timelock) == address(0), "Timelock already deployed");
-
+    DeploymentConfigurationLocal.TimelockDeploymentConfiguration memory _config =
+      config._getTimelockDeploymentConfiguration();
     DeployTimelock _script = new DeployTimelock();
     _script.setLoggingSilenced(true);
-    timelock = _script.run(baseInput.MAIN_DAO_GOVERNOR());
+    timelock = _script.run(deployer, _config);
   }
 
   function _step3_deployVetoGovernor() internal {
     require(address(vetoGovernor) == address(0), "Veto governor already deployed");
     require(address(timelock) != address(0), "Timelock must be deployed first");
 
+    DeploymentConfigurationLocal.VetoGovernorDeploymentConfiguration memory _config =
+      config._getVetoGovernorDeploymentConfiguration();
     DeployVetoGovernor _script = new DeployVetoGovernor();
     _script.setLoggingSilenced(true);
-    vetoGovernor = _script.run(baseInput.MAIN_DAO_GOVERNOR(), timelock);
+    vetoGovernor = _script.run(deployer, timelock, _config);
   }
 
   function _step4_deployCouncilGovernor() internal {
@@ -102,9 +99,11 @@ contract OptimisticGovernanceDeployment is Test {
     require(address(councilToken) != address(0), "Council token must be deployed first");
     require(address(vetoGovernor) != address(0), "Veto governor must be deployed first");
 
+    DeploymentConfigurationLocal.CouncilGovernorDeploymentConfiguration memory _config =
+      config._getCouncilGovernorDeploymentConfiguration();
     DeployCouncilGovernor _script = new DeployCouncilGovernor();
     _script.setLoggingSilenced(true);
-    councilGovernor = _script.run(baseInput.MAIN_DAO_GOVERNOR(), councilToken, vetoGovernor);
+    councilGovernor = _script.run(deployer, councilToken, vetoGovernor, _config);
   }
 
   /// @notice Test the complete deployment flow with verification after each phase.
@@ -113,37 +112,34 @@ contract OptimisticGovernanceDeployment is Test {
     _step1_deployCouncilTokenAndMint();
 
     // Verify Step 1
-    assertEq(councilToken.name(), councilERC20Input.NAME());
-    assertEq(councilToken.symbol(), councilERC20Input.SYMBOL());
-    assertEq(councilToken.owner(), councilERC20Input.MAIN_DAO_GOVERNOR());
-    assertEq(councilToken.MAX_TOKENS_PER_MEMBER(), councilERC20Input.MAX_TOKENS_PER_MEMBER());
-    for (uint256 _i = 0; _i < councilERC20Input.COUNCIL_MEMBERS_LENGTH(); _i++) {
-      assertEq(
-        councilToken.balanceOf(councilERC20Input.COUNCIL_MEMBERS(_i)),
-        councilERC20Input.MAX_TOKENS_PER_MEMBER()
-      );
+    assertEq(councilToken.name(), input.COUNCIL_TOKEN_NAME());
+    assertEq(councilToken.symbol(), input.COUNCIL_TOKEN_SYMBOL());
+    assertEq(councilToken.owner(), input.MAIN_DAO_GOVERNOR());
+    assertEq(councilToken.MAX_TOKENS_PER_MEMBER(), input.MAX_TOKENS_PER_MEMBER());
+    for (uint256 _i = 0; _i < input.COUNCIL_MEMBERS_LENGTH(); _i++) {
+      assertEq(councilToken.balanceOf(input.COUNCIL_MEMBERS(_i)), input.MAX_TOKENS_PER_MEMBER());
     }
 
     // Step 2: Deploy the veto timelock and confirm parameters.
     _step2_deployTimelock();
 
     // Verify Step 2
-    assertEq(timelock.getMinDelay(), timelockInput.TIMELOCK_MIN_DELAY());
+    assertEq(timelock.getMinDelay(), input.TIMELOCK_MIN_DELAY());
 
     // Step 3: Deploy the veto governor and ensure wiring to the timelock.
     _step3_deployVetoGovernor();
 
     // Verify Step 3
-    assertEq(vetoGovernor.name(), vetoInput.VETO_GOVERNOR_NAME());
-    assertEq(address(vetoGovernor.token()), address(vetoInput.MAIN_DAO_TOKEN()));
-    assertEq(vetoGovernor.votingDelay(), vetoInput.INITIAL_VETO_GOVERNOR_VOTING_DELAY());
-    assertEq(vetoGovernor.votingPeriod(), vetoInput.INITIAL_VETO_GOVERNOR_VOTING_PERIOD());
-    assertEq(vetoGovernor.proposalThreshold(), vetoInput.INITIAL_VETO_GOVERNOR_PROPOSAL_THRESHOLD());
-    assertEq(vetoGovernor.vetoOverrideRole(), vetoInput.VETO_OVERRIDE_ROLE());
-    assertEq(vetoGovernor.vetoOverrideDuration(), vetoInput.VETO_OVERRIDE_DURATION());
-    assertEq(vetoGovernor.vetoGuardian(), vetoInput.VETO_GUARDIAN());
+    assertEq(vetoGovernor.name(), input.VETO_GOVERNOR_NAME());
+    assertEq(address(vetoGovernor.token()), address(input.MAIN_DAO_TOKEN()));
+    assertEq(vetoGovernor.votingDelay(), input.VETO_GOVERNOR_INITIAL_VOTING_DELAY());
+    assertEq(vetoGovernor.votingPeriod(), input.VETO_GOVERNOR_INITIAL_VOTING_PERIOD());
+    assertEq(vetoGovernor.proposalThreshold(), input.VETO_GOVERNOR_INITIAL_PROPOSAL_THRESHOLD());
+    assertEq(vetoGovernor.vetoOverrideRole(), input.VETO_OVERRIDE_ROLE());
+    assertEq(vetoGovernor.vetoOverrideDuration(), input.VETO_OVERRIDE_DURATION());
+    assertEq(vetoGovernor.vetoGuardian(), input.VETO_GUARDIAN());
     assertEq(address(vetoGovernor.timelock()), address(timelock));
-    assertEq(vetoGovernor.owner(), vetoInput.GOVERNOR_ADMIN());
+    assertEq(vetoGovernor.owner(), input.GOVERNOR_ADMIN());
 
     // Step 4: Deploy the council governor and ensure linkage to the veto governor.
     _step4_deployCouncilGovernor();
@@ -151,15 +147,14 @@ contract OptimisticGovernanceDeployment is Test {
     // Verify Step 4
     assertEq(vetoGovernor.COUNCIL(), address(councilGovernor));
 
-    assertEq(councilGovernor.name(), councilInput.COUNCIL_GOVERNOR_NAME());
+    assertEq(councilGovernor.name(), input.COUNCIL_GOVERNOR_NAME());
     assertEq(address(councilGovernor.token()), address(councilToken));
     assertEq(address(councilGovernor.councilVetoGovernor()), address(vetoGovernor));
-    assertEq(councilGovernor.votingDelay(), councilInput.INITIAL_COUNCIL_GOVERNOR_VOTING_DELAY());
-    assertEq(councilGovernor.votingPeriod(), councilInput.INITIAL_COUNCIL_GOVERNOR_VOTING_PERIOD());
+    assertEq(councilGovernor.votingDelay(), input.COUNCIL_GOVERNOR_INITIAL_VOTING_DELAY());
+    assertEq(councilGovernor.votingPeriod(), input.COUNCIL_GOVERNOR_INITIAL_VOTING_PERIOD());
     assertEq(
-      councilGovernor.proposalThreshold(),
-      councilInput.INITIAL_COUNCIL_GOVERNOR_PROPOSAL_THRESHOLD()
+      councilGovernor.proposalThreshold(), input.COUNCIL_GOVERNOR_INITIAL_PROPOSAL_THRESHOLD()
     );
-    assertEq(councilGovernor.owner(), councilInput.GOVERNOR_ADMIN());
+    assertEq(councilGovernor.owner(), input.GOVERNOR_ADMIN());
   }
 }


### PR DESCRIPTION
Existing scripts use mixin to get constructor parameters, but then we will need to write separate script contracts for local testing and deployment.
With dependency injection pattern, we allow the script to fetch constructor parameters based on the deployment context.