### PR TITLE
Fix C-01: COMP Token Is Incompatible with GovernorVotes-Based Veto Governor

### DIFF
--- a/script/DeployCompoundGovernorsAndGrantRoles.s.sol
+++ b/script/DeployCompoundGovernorsAndGrantRoles.s.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.30;
+
+// External Dependencies
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC5805} from "@openzeppelin/contracts/interfaces/IERC5805.sol";
+import {IGovernor} from "@openzeppelin/contracts/governance/Governor.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+
+// Internal Dependencies
+import {CouncilERC20} from "src/CouncilERC20.sol";
+import {BasicCouncilGovernor} from "src/BasicCouncilGovernor.sol";
+import {CompoundCouncilVetoGovernor} from "src/CompoundCouncilVetoGovernor.sol";
+
+// Script Dependencies
+import {DeployGovernorsAndGrantRoles} from "script/DeployGovernorsAndGrantRoles.s.sol";
+
+contract DeployCompoundGovernorsAndGrantRoles is DeployGovernorsAndGrantRoles {
+  struct CompoundVetoGovernorDeploymentConfiguration {
+    string vetoGovernorName;
+    IERC20 mainDaoToken;
+    uint48 vetoGovernorInitialVotingDelay;
+    uint32 vetoGovernorInitialVotingPeriod;
+    uint256 vetoGovernorInitialProposalThreshold;
+    address vetoOverrideRole;
+    uint48 vetoOverrideDuration;
+    uint48 votingPeriodExtension;
+    uint16 votingPeriodExtensionThresholdPct;
+    address vetoGuardian;
+    address vetoGovernorAdmin;
+  }
+
+  function run(
+    address _deployer,
+    TimelockController _timelock,
+    CouncilGovernorDeploymentConfiguration memory _councilConfig,
+    CompoundVetoGovernorDeploymentConfiguration memory _vetoConfig,
+    CouncilERC20 _councilToken
+  )
+    public
+    returns (BasicCouncilGovernor councilGovernor, CompoundCouncilVetoGovernor vetoGovernor)
+  {
+    vm.startBroadcast(_deployer);
+
+    BasicCouncilGovernor.InitialCouncilParams memory _councilParams =
+      BasicCouncilGovernor.InitialCouncilParams(
+        _councilConfig.councilGovernorInitialVotingDelay,
+        _councilConfig.councilGovernorInitialVotingPeriod,
+        _councilConfig.councilGovernorInitialProposalThreshold,
+        _councilConfig.councilGovernorInitialQuorumFraction,
+        _councilConfig.councilGovernorInitialSuperQuorumFraction
+      );
+
+    councilGovernor = new BasicCouncilGovernor(
+      _councilConfig.councilGovernorName,
+      IERC5805(_councilToken),
+      IGovernor(_predictVetoGovernorAddress(_deployer)),
+      _councilConfig.councilGovernorAdmin,
+      _councilParams
+    );
+
+    CompoundCouncilVetoGovernor.ConstructorParams memory _params =
+      CompoundCouncilVetoGovernor.ConstructorParams({
+        name: _vetoConfig.vetoGovernorName,
+        token: _vetoConfig.mainDaoToken,
+        votingDelay: _vetoConfig.vetoGovernorInitialVotingDelay,
+        votingPeriod: _vetoConfig.vetoGovernorInitialVotingPeriod,
+        proposalThreshold: _vetoConfig.vetoGovernorInitialProposalThreshold,
+        vetoGuardian: _vetoConfig.vetoGuardian,
+        vetoOverrideRole: _vetoConfig.vetoOverrideRole,
+        vetoOverrideDuration: _vetoConfig.vetoOverrideDuration,
+        votingPeriodExtension: _vetoConfig.votingPeriodExtension,
+        votingPeriodExtensionThresholdPct: _vetoConfig.votingPeriodExtensionThresholdPct,
+        timelock: TimelockController(_timelock),
+        governorAdmin: _vetoConfig.vetoGovernorAdmin,
+        council: address(councilGovernor)
+      });
+
+    vetoGovernor = new CompoundCouncilVetoGovernor(_params);
+
+    _grantVetoGovernorRoles(_deployer, address(vetoGovernor), _timelock);
+    vm.stopBroadcast();
+
+    _log("councilGovernor", address(councilGovernor));
+    _log("vetoGovernor", address(vetoGovernor));
+  }
+}

--- a/script/DeployGovernorsAndGrantRoles.s.sol
+++ b/script/DeployGovernorsAndGrantRoles.s.sol
@@ -62,11 +62,11 @@ contract DeployGovernorsAndGrantRoles is Script, BaseLogger {
 
   function _grantVetoGovernorRoles(
     address _deployer,
-    BasicCouncilVetoGovernor _vetoGovernor,
+    address _vetoGovernor,
     TimelockController _timelock
   ) internal {
-    _timelock.grantRole(_timelock.EXECUTOR_ROLE(), address(_vetoGovernor));
-    _timelock.grantRole(_timelock.PROPOSER_ROLE(), address(_vetoGovernor));
+    _timelock.grantRole(_timelock.EXECUTOR_ROLE(), _vetoGovernor);
+    _timelock.grantRole(_timelock.PROPOSER_ROLE(), _vetoGovernor);
     _timelock.renounceRole(_timelock.DEFAULT_ADMIN_ROLE(), _deployer);
   }
 
@@ -116,7 +116,7 @@ contract DeployGovernorsAndGrantRoles is Script, BaseLogger {
 
     vetoGovernor = new BasicCouncilVetoGovernor(_params);
 
-    _grantVetoGovernorRoles(_deployer, vetoGovernor, _timelock);
+    _grantVetoGovernorRoles(_deployer, address(vetoGovernor), _timelock);
     vm.stopBroadcast();
 
     _log("councilGovernor", address(councilGovernor));

--- a/script/DeploymentConfigurationTest.sol
+++ b/script/DeploymentConfigurationTest.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.30;
 
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 // Script Dependencies
 import {DeploymentConfigurationBase} from "script/DeploymentConfigurationBase.sol";
 import {
@@ -9,13 +11,17 @@ import {
 import {DeployAndMintCouncilERC20} from "script/DeployAndMintCouncilERC20.s.sol";
 import {DeployTimelock} from "script/DeployTimelock.s.sol";
 import {DeployGovernorsAndGrantRoles} from "script/DeployGovernorsAndGrantRoles.s.sol";
+import {
+  DeployCompoundGovernorsAndGrantRoles
+} from "script/DeployCompoundGovernorsAndGrantRoles.s.sol";
 
 contract DeploymentConfigurationTest is
   DeploymentConfigurationBase,
   DeploymentInputMainnetForkTest,
   DeployAndMintCouncilERC20,
   DeployTimelock,
-  DeployGovernorsAndGrantRoles
+  DeployGovernorsAndGrantRoles,
+  DeployCompoundGovernorsAndGrantRoles
 {
   function _getBaseDeploymentConfiguration()
     public
@@ -73,6 +79,27 @@ contract DeploymentConfigurationTest is
       votingPeriodExtension: VOTING_PERIOD_EXTENSION,
       votingPeriodExtensionThresholdPct: VOTING_PERIOD_EXTENSION_THRESHOLD_PCT,
       vetoThresholdNumerator: VETO_GOVERNOR_INITIAL_VETO_THRESHOLD_FRACTION,
+      vetoGuardian: VETO_GUARDIAN,
+      vetoGovernorAdmin: _baseConfig.governorAdmin
+    });
+  }
+
+  function _getCompoundVetoGovernorDeploymentConfiguration()
+    public
+    view
+    returns (CompoundVetoGovernorDeploymentConfiguration memory)
+  {
+    BaseDeploymentConfiguration memory _baseConfig = _getBaseDeploymentConfiguration();
+    return CompoundVetoGovernorDeploymentConfiguration({
+      vetoGovernorName: COMPOUND_VETO_GOVERNOR_NAME,
+      mainDaoToken: IERC20(address(_baseConfig.mainDaoToken)),
+      vetoGovernorInitialVotingDelay: COMPOUND_VETO_GOVERNOR_INITIAL_VOTING_DELAY,
+      vetoGovernorInitialVotingPeriod: COMPOUND_VETO_GOVERNOR_INITIAL_VOTING_PERIOD,
+      vetoGovernorInitialProposalThreshold: VETO_GOVERNOR_INITIAL_PROPOSAL_THRESHOLD,
+      vetoOverrideRole: VETO_OVERRIDE_ROLE,
+      vetoOverrideDuration: VETO_OVERRIDE_DURATION,
+      votingPeriodExtension: VOTING_PERIOD_EXTENSION,
+      votingPeriodExtensionThresholdPct: VOTING_PERIOD_EXTENSION_THRESHOLD_PCT,
       vetoGuardian: VETO_GUARDIAN,
       vetoGovernorAdmin: _baseConfig.governorAdmin
     });

--- a/script/deploy-constants/DeploymentInputMainnetForkTest.sol
+++ b/script/deploy-constants/DeploymentInputMainnetForkTest.sol
@@ -59,6 +59,13 @@ contract DeploymentInputMainnetForkTest {
   // Veto governor veto guardian
   address public VETO_GUARDIAN;
 
+  // Compound veto governor name (COMP-style `getPriorVotes`)
+  string public constant COMPOUND_VETO_GOVERNOR_NAME = "CompoundCouncilVetoGovernor";
+  // Compound veto governor voting delay (in blocks)
+  uint48 public constant COMPOUND_VETO_GOVERNOR_INITIAL_VOTING_DELAY = 300;
+  // Compound veto governor voting period (in blocks)
+  uint32 public constant COMPOUND_VETO_GOVERNOR_INITIAL_VOTING_PERIOD = 7200;
+
   // Council governor name
   string public constant COUNCIL_GOVERNOR_NAME = "BasicCouncilGovernor";
   // Council governor voting delay

--- a/script/deploy-constants/DeploymentInputSepolia.sol
+++ b/script/deploy-constants/DeploymentInputSepolia.sol
@@ -59,6 +59,13 @@ contract DeploymentInputSepolia {
   // Veto governor veto guardian
   address public VETO_GUARDIAN;
 
+  // Compound veto governor name (COMP-style `getPriorVotes`)
+  string public constant COMPOUND_VETO_GOVERNOR_NAME = "CompoundCouncilVetoGovernor";
+  // Compound veto governor voting delay (in blocks)
+  uint48 public constant COMPOUND_VETO_GOVERNOR_INITIAL_VOTING_DELAY = 300;
+  // Compound veto governor voting period (in blocks)
+  uint32 public constant COMPOUND_VETO_GOVERNOR_INITIAL_VOTING_PERIOD = 7200;
+
   // Council governor name
   string public constant COUNCIL_GOVERNOR_NAME = "BasicCouncilGovernor";
   // Council governor voting delay

--- a/src/CompoundCouncilVetoGovernor.sol
+++ b/src/CompoundCouncilVetoGovernor.sol
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.30;
+
+// External Dependencies
+import {Governor} from "@openzeppelin/contracts/governance/Governor.sol";
+import {GovernorSettings} from "@openzeppelin/contracts/governance/extensions/GovernorSettings.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {
+  GovernorTimelockControl,
+  TimelockController
+} from "@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol";
+
+// Internal Dependencies
+import {GovernorVetoCountingSimple} from "src/extensions/GovernorVetoCountingSimple.sol";
+import {GovernorVetoOverride} from "src/extensions/GovernorVetoOverride.sol";
+import {GovernorVetoGuardian} from "src/extensions/GovernorVetoGuardian.sol";
+import {GovernorAdmin} from "src/extensions/GovernorAdmin.sol";
+import {GovernorExtendVetoPeriod} from "src/extensions/GovernorExtendVetoPeriod.sol";
+import {GovernorVotesComp} from "src/extensions/GovernorVotesComp.sol";
+
+/// @title CompoundCouncilVetoGovernor
+/// @author [ScopeLift](https://scopelift.co)
+/// @notice Veto governor variant for COMP-style tokens (legacy `getPriorVotes` snapshots).
+/// @dev This governor uses a block-number clock. `votingDelay`, `votingPeriod`, and all timepoints
+/// are expressed in blocks (not seconds).
+contract CompoundCouncilVetoGovernor is
+  Governor,
+  GovernorVotesComp,
+  GovernorAdmin,
+  GovernorSettings,
+  GovernorVetoCountingSimple,
+  GovernorVetoGuardian,
+  GovernorVetoOverride,
+  GovernorExtendVetoPeriod,
+  GovernorTimelockControl
+{
+  /// @notice Data structure for deploying the `CouncilVetoGovernor`.
+  /// @param name The name of the council veto governor.
+  /// @param token The token used to veto governance proposals.
+  /// @param votingDelay The delay before voting on a proposal begins (in blocks).
+  /// @param votingPeriod The period of time voting will take place (in blocks).
+  /// @param proposalThreshold The number of tokens needed to create a proposal.
+  /// @param vetoGuardian The address authorized to veto proposals.
+  /// @param vetoOverrideRole The address authorized to override vetoed proposals.
+  /// @param vetoOverrideDuration Time window for overrides after proposal deadline (in blocks).
+  /// @param votingPeriodExtension Voting period extension amount (in blocks).
+  /// @param votingPeriodExtensionThresholdPct Minor threshold percentage for extension.
+  /// @param timelock The timelock contract used for managing proposals.
+  /// @param governorAdmin The address authorized to change governance parameters.
+  /// @param council The address of the council governor.
+  struct ConstructorParams {
+    string name;
+    IERC20 token;
+    uint48 votingDelay;
+    uint32 votingPeriod;
+    uint256 proposalThreshold;
+    address vetoGuardian;
+    address vetoOverrideRole;
+    uint48 vetoOverrideDuration;
+    uint48 votingPeriodExtension;
+    uint16 votingPeriodExtensionThresholdPct;
+    TimelockController timelock;
+    address governorAdmin;
+    address council;
+  }
+
+  address public immutable COUNCIL;
+
+  modifier onlyCouncil() virtual {
+    require(_msgSender() == COUNCIL, "Only council");
+    _;
+  }
+
+  constructor(ConstructorParams memory _params)
+    Governor(_params.name)
+    GovernorVotesComp(_params.token)
+    GovernorVetoGuardian(_params.vetoGuardian)
+    GovernorSettings(_params.votingDelay, _params.votingPeriod, _params.proposalThreshold)
+    GovernorVetoOverride(_params.vetoOverrideRole, _params.vetoOverrideDuration)
+    GovernorExtendVetoPeriod(
+      _params.votingPeriodExtension, _params.votingPeriodExtensionThresholdPct
+    )
+    GovernorTimelockControl(_params.timelock)
+    GovernorAdmin(_params.governorAdmin)
+  {
+    COUNCIL = _params.council;
+  }
+
+  function votingDelay()
+    public
+    view
+    virtual
+    override(Governor, GovernorSettings)
+    returns (uint256)
+  {
+    return GovernorSettings.votingDelay();
+  }
+
+  function votingPeriod()
+    public
+    view
+    virtual
+    override(Governor, GovernorSettings)
+    returns (uint256)
+  {
+    return GovernorSettings.votingPeriod();
+  }
+
+  function proposalThreshold()
+    public
+    view
+    virtual
+    override(Governor, GovernorSettings)
+    returns (uint256)
+  {
+    return GovernorSettings.proposalThreshold();
+  }
+
+  function state(uint256 _proposalId)
+    public
+    view
+    virtual
+    override(Governor, GovernorTimelockControl, GovernorVetoGuardian, GovernorVetoOverride)
+    returns (ProposalState)
+  {
+    return GovernorVetoOverride.state(_proposalId);
+  }
+
+  function proposalDeadline(uint256 _proposalId)
+    public
+    view
+    virtual
+    override(Governor, GovernorExtendVetoPeriod)
+    returns (uint256)
+  {
+    return GovernorExtendVetoPeriod.proposalDeadline(_proposalId);
+  }
+
+  function proposalVotes(uint256 _proposalId)
+    public
+    view
+    virtual
+    override(GovernorExtendVetoPeriod, GovernorVetoCountingSimple)
+    returns (uint256)
+  {
+    return GovernorVetoCountingSimple.proposalVotes(_proposalId);
+  }
+
+  function vetoThreshold(uint256)
+    public
+    view
+    virtual
+    override(GovernorVetoCountingSimple, GovernorExtendVetoPeriod)
+    returns (uint256)
+  {
+    return 400_000e18;
+  }
+
+  function proposalNeedsQueuing(uint256 _proposalId)
+    public
+    view
+    virtual
+    override(Governor, GovernorTimelockControl)
+    returns (bool)
+  {
+    return GovernorTimelockControl.proposalNeedsQueuing(_proposalId);
+  }
+
+  function propose(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) public virtual override onlyCouncil returns (uint256) {
+    return super.propose(_targets, _values, _calldatas, _description);
+  }
+
+  function execute(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    bytes32 _descriptionHash
+  ) public payable virtual override onlyCouncil returns (uint256) {
+    return super.execute(_targets, _values, _calldatas, _descriptionHash);
+  }
+
+  function _checkGovernance() internal virtual override(Governor, GovernorAdmin) {
+    GovernorAdmin._checkGovernance();
+  }
+
+  function _executor()
+    internal
+    view
+    virtual
+    override(Governor, GovernorTimelockControl)
+    returns (address)
+  {
+    return GovernorTimelockControl._executor();
+  }
+
+  function _cancel(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    bytes32 _descriptionHash
+  ) internal virtual override(Governor, GovernorTimelockControl) returns (uint256) {
+    return GovernorTimelockControl._cancel(_targets, _values, _calldatas, _descriptionHash);
+  }
+
+  function _queueOperations(
+    uint256 _proposalId,
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    bytes32 _descriptionHash
+  ) internal virtual override(Governor, GovernorTimelockControl) returns (uint48) {
+    return GovernorTimelockControl._queueOperations(
+      _proposalId, _targets, _values, _calldatas, _descriptionHash
+    );
+  }
+
+  function _executeOperations(
+    uint256 _proposalId,
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    bytes32 _descriptionHash
+  ) internal virtual override(Governor, GovernorTimelockControl) {
+    GovernorTimelockControl._executeOperations(
+      _proposalId, _targets, _values, _calldatas, _descriptionHash
+    );
+  }
+
+  function _tallyUpdated(uint256 _proposalId)
+    internal
+    virtual
+    override(Governor, GovernorExtendVetoPeriod)
+  {
+    GovernorExtendVetoPeriod._tallyUpdated(_proposalId);
+  }
+}

--- a/src/extensions/GovernorVotesComp.sol
+++ b/src/extensions/GovernorVotesComp.sol
@@ -21,15 +21,15 @@ interface ICompVotes {
 /// @notice Governor vote-weight extension for COMP-style tokens that expose `getPriorVotes`.
 /// @dev COMP uses block number checkpoints and does not implement ERC-5805 snapshot methods.
 abstract contract GovernorVotesComp is Governor {
-  IERC20 private immutable _token;
+  IERC20 private immutable TOKEN;
 
   constructor(IERC20 tokenAddress) {
-    _token = tokenAddress;
+    TOKEN = tokenAddress;
   }
 
   /// @dev The token that voting power is sourced from.
   function token() public view virtual returns (IERC20) {
-    return _token;
+    return TOKEN;
   }
 
   /// @dev Matches COMP to use block number.
@@ -56,6 +56,6 @@ abstract contract GovernorVotesComp is Governor {
     override
     returns (uint256)
   {
-    return uint256(ICompVotes(address(_token)).getPriorVotes(account, timepoint));
+    return uint256(ICompVotes(address(TOKEN)).getPriorVotes(account, timepoint));
   }
 }

--- a/src/extensions/GovernorVotesComp.sol
+++ b/src/extensions/GovernorVotesComp.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Governor} from "@openzeppelin/contracts/governance/Governor.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @title ICompVotes
+/// @author [ScopeLift](https://scopelift.co)
+/// @notice Minimal interface for COMP-style voting power checkpoints.
+interface ICompVotes {
+  /// @notice Returns the voting power of `account` at `blockNumber`.
+  /// @dev Implementations generally require `blockNumber < block.number` (strictly prior).
+  /// @param account The address to query voting power for.
+  /// @param blockNumber The historical block number to query at.
+  /// @return The voting power at `blockNumber`.
+  function getPriorVotes(address account, uint256 blockNumber) external view returns (uint96);
+}
+
+/// @title GovernorVotesComp
+/// @author [ScopeLift](https://scopelift.co)
+/// @notice Governor vote-weight extension for COMP-style tokens that expose `getPriorVotes`.
+/// @dev COMP uses block number checkpoints and does not implement ERC-5805 snapshot methods.
+abstract contract GovernorVotesComp is Governor {
+  IERC20 private immutable _token;
+
+  constructor(IERC20 tokenAddress) {
+    _token = tokenAddress;
+  }
+
+  /// @dev The token that voting power is sourced from.
+  function token() public view virtual returns (IERC20) {
+    return _token;
+  }
+
+  /// @dev Matches COMP to use block number.
+  function clock() public view virtual override returns (uint48) {
+    return uint48(block.number);
+  }
+
+  /// @dev Machine-readable description of the clock as specified in ERC-6372.
+  function CLOCK_MODE() public pure virtual override returns (string memory) {
+    return "mode=blocknumber&from=default";
+  }
+
+  /// @notice Returns the voting weight of `account` at `timepoint`.
+  /// @param account The address to query voting power for.
+  /// @param timepoint The historical block number to query at.
+  function _getVotes(
+    address account,
+    uint256 timepoint,
+    bytes memory /*params*/
+  )
+    internal
+    view
+    virtual
+    override
+    returns (uint256)
+  {
+    return uint256(ICompVotes(address(_token)).getPriorVotes(account, timepoint));
+  }
+}

--- a/test/CompoundCouncilVetoGovernor.integration.t.sol
+++ b/test/CompoundCouncilVetoGovernor.integration.t.sol
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+import {
+  GovernorCountingSimple
+} from "@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol";
+
+import {BasicCouncilGovernor} from "src/BasicCouncilGovernor.sol";
+import {CompoundCouncilVetoGovernor} from "src/CompoundCouncilVetoGovernor.sol";
+import {CouncilERC20} from "src/CouncilERC20.sol";
+
+import {DeployAndMintCouncilERC20} from "script/DeployAndMintCouncilERC20.s.sol";
+import {DeployTimelock} from "script/DeployTimelock.s.sol";
+import {
+  DeployCompoundGovernorsAndGrantRoles
+} from "script/DeployCompoundGovernorsAndGrantRoles.s.sol";
+import {DeploymentConfigurationTest} from "script/DeploymentConfigurationTest.sol";
+
+interface IComp is IERC20 {
+  function delegate(address delegatee) external;
+  function getPriorVotes(address account, uint256 blockNumber) external view returns (uint96);
+}
+
+/// @notice Integration test using mainnet COMP token on a fork.
+/// @dev Requires `MAINNET_RPC_URL` to be set for Foundry's `mainnet` RPC alias.
+contract CompoundCouncilVetoGovernorIntegrationTest is Test {
+  struct Proposal {
+    address[] targets;
+    uint256[] values;
+    bytes[] calldatas;
+    string description;
+  }
+
+  IComp internal constant COMP = IComp(0xc00e94Cb662C3520282E6f5717214004A7f26888);
+
+  address internal deployer = makeAddr("deployer");
+  address internal councilMember = makeAddr("councilMember");
+  address internal voter = makeAddr("voter");
+  address internal nonCouncil = makeAddr("nonCouncil");
+
+  TimelockController internal timelock;
+  CouncilERC20 internal councilToken;
+  BasicCouncilGovernor internal councilGovernor;
+  CompoundCouncilVetoGovernor internal vetoGovernor;
+  DeploymentConfigurationTest internal config;
+
+  function setUp() public {
+    string memory rpcUrl = vm.rpcUrl("mainnet");
+    uint256 forkBlock = 23_810_240;
+    vm.createSelectFork(rpcUrl, forkBlock);
+
+    config = new DeploymentConfigurationTest();
+    deployer = config.MAIN_DAO_GOVERNOR();
+    councilMember = config.COUNCIL_MEMBERS(0);
+
+    DeployAndMintCouncilERC20 councilTokenScript = new DeployAndMintCouncilERC20();
+    councilTokenScript.setLoggingSilenced(true);
+
+    councilToken =
+      councilTokenScript.run(deployer, config._getCouncilERC20DeploymentConfiguration());
+    vm.warp(block.timestamp + 1);
+
+    DeployTimelock timelockScript = new DeployTimelock();
+    timelockScript.setLoggingSilenced(true);
+    timelock = timelockScript.run(deployer, config._getTimelockDeploymentConfiguration());
+
+    DeployCompoundGovernorsAndGrantRoles governorsScript =
+      new DeployCompoundGovernorsAndGrantRoles();
+    governorsScript.setLoggingSilenced(true);
+
+    DeployCompoundGovernorsAndGrantRoles.CompoundVetoGovernorDeploymentConfiguration memory
+      vetoConfig = config._getCompoundVetoGovernorDeploymentConfiguration();
+    // Override the placeholder token address in the default test config with the real COMP token.
+    vetoConfig.mainDaoToken = IERC20(address(COMP));
+
+    (councilGovernor, vetoGovernor) = governorsScript.run(
+      deployer,
+      timelock,
+      config._getCouncilGovernorDeploymentConfiguration(),
+      vetoConfig,
+      councilToken
+    );
+  }
+
+  function _buildEmptyProposal(string memory _description)
+    internal
+    pure
+    returns (Proposal memory _proposal)
+  {
+    address[] memory _targets = new address[](1);
+    uint256[] memory _values = new uint256[](1);
+    bytes[] memory _calldatas = new bytes[](1);
+    _proposal = Proposal(_targets, _values, _calldatas, _description);
+  }
+
+  function _buildEmptyProposal() internal pure returns (Proposal memory _proposal) {
+    _proposal = _buildEmptyProposal("Empty proposal");
+  }
+
+  function _queueProposalToVetoGovernor() internal returns (uint256 _proposalId) {
+    Proposal memory _proposal = _buildEmptyProposal();
+
+    vm.prank(councilMember);
+    _proposalId = councilGovernor.propose(
+      _proposal.targets, _proposal.values, _proposal.calldatas, _proposal.description
+    );
+
+    vm.warp(councilGovernor.proposalSnapshot(_proposalId) + 1);
+    for (uint256 i = 0; i < 4; i++) {
+      vm.prank(config.COUNCIL_MEMBERS(i));
+      councilGovernor.castVote(_proposalId, uint8(GovernorCountingSimple.VoteType.For));
+    }
+
+    vm.warp(councilGovernor.proposalDeadline(_proposalId) + 1);
+
+    vm.prank(councilMember);
+    councilGovernor.queue(
+      _proposal.targets,
+      _proposal.values,
+      _proposal.calldatas,
+      keccak256(bytes(_proposal.description))
+    );
+  }
+
+  function _dealAndDelegateComp(address _voter, uint256 _amount) internal {
+    deal(address(COMP), _voter, _amount);
+    vm.prank(_voter);
+    COMP.delegate(_voter);
+
+    vm.roll(block.number + 1);
+  }
+}
+
+contract CompoundCouncilVetoGovernorIntegrationSmokeTest is
+  CompoundCouncilVetoGovernorIntegrationTest
+{
+  function test_ParamsSetCorrectly(uint256 _timepoint) public view {
+    assertEq(vetoGovernor.CLOCK_MODE(), "mode=blocknumber&from=default");
+    assertEq(vetoGovernor.clock(), uint48(block.number));
+    assertEq(vetoGovernor.vetoThreshold(_timepoint), 400_000e18);
+  }
+
+  function test_TimestampProgressionDoesNotChangeState() public {
+    _dealAndDelegateComp(voter, 1e18);
+
+    uint256 _proposalId = _queueProposalToVetoGovernor();
+    IGovernor.ProposalState _before = vetoGovernor.state(_proposalId);
+
+    vm.warp(block.timestamp + vetoGovernor.votingDelay() + 1);
+    IGovernor.ProposalState _after = vetoGovernor.state(_proposalId);
+
+    assertEq(vetoGovernor.clock(), block.number);
+    assertNotEq(vetoGovernor.clock(), block.timestamp);
+    assertEq(uint8(_before), uint8(IGovernor.ProposalState.Pending));
+    assertEq(uint8(_after), uint8(IGovernor.ProposalState.Pending));
+  }
+
+  function test_VoterCastVetoVoteWithCOMP() public {
+    _dealAndDelegateComp(voter, 1e18);
+
+    uint256 _proposalId = _queueProposalToVetoGovernor();
+
+    uint256 snapshot = vetoGovernor.proposalSnapshot(_proposalId);
+    vm.roll(vetoGovernor.proposalSnapshot(_proposalId) + 1);
+
+    vm.expectCall(
+      address(COMP), abi.encodeWithSelector(IComp.getPriorVotes.selector, voter, snapshot)
+    );
+    vm.prank(voter);
+    vetoGovernor.castVote(_proposalId, uint8(GovernorCountingSimple.VoteType.Against));
+
+    assertEq(vetoGovernor.proposalVotes(_proposalId), uint256(COMP.getPriorVotes(voter, snapshot)));
+  }
+
+  function testFuzz_StateIsSucceededWhenVetoVotesBelowVetoThreshold(uint256 _weight) public {
+    _weight = bound(_weight, 0, 400_000e18 - 1);
+    _dealAndDelegateComp(voter, _weight);
+
+    uint256 _proposalId = _queueProposalToVetoGovernor();
+
+    uint256 snapshot = vetoGovernor.proposalSnapshot(_proposalId);
+    vm.roll(snapshot + 1);
+    vm.prank(voter);
+    vetoGovernor.castVote(_proposalId, uint8(GovernorCountingSimple.VoteType.Against));
+
+    vm.roll(vetoGovernor.proposalDeadline(_proposalId) + 1);
+    assertEq(uint8(vetoGovernor.state(_proposalId)), uint8(IGovernor.ProposalState.Succeeded));
+  }
+
+  function testFuzz_StateIsDefeatedWhenVetoVotesAboveVetoThreshold(uint256 _weight) public {
+    _weight = bound(_weight, 400_000e18, COMP.totalSupply() - 1);
+    _dealAndDelegateComp(voter, _weight);
+
+    uint256 _proposalId = _queueProposalToVetoGovernor();
+
+    uint256 snapshot = vetoGovernor.proposalSnapshot(_proposalId);
+    vm.roll(snapshot + 1);
+    vm.prank(voter);
+    vetoGovernor.castVote(_proposalId, uint8(GovernorCountingSimple.VoteType.Against));
+
+    vm.roll(vetoGovernor.proposalDeadline(_proposalId) + 1);
+    assertEq(uint8(vetoGovernor.state(_proposalId)), uint8(IGovernor.ProposalState.Defeated));
+  }
+}


### PR DESCRIPTION
- Add `GovernorVotesComp`
- Add `CompoundVetoGovernor`
- Update scripts to deploy `CompoundVetoGovernor`
- Add fork tests that test against mainnet COMP