### PR TITLE
Fix L-02: forward `msg.value` in `execute` call

### DIFF
--- a/src/extensions/GovernorCouncilQueuing.sol
+++ b/src/extensions/GovernorCouncilQueuing.sol
@@ -163,7 +163,7 @@ abstract contract GovernorCouncilQueuing is Governor {
     bytes[] memory _calldatas,
     bytes32 _descriptionHash
   ) internal virtual override {
-    councilVetoGovernor.execute(_targets, _values, _calldatas, _descriptionHash);
+    councilVetoGovernor.execute{value: msg.value}(_targets, _values, _calldatas, _descriptionHash);
   }
 
   /// @dev Overridden version of the {Governor-_cancel} function to cancel a proposal and clean up

--- a/test/BasicCouncilVetoGovernor.integration.t.sol
+++ b/test/BasicCouncilVetoGovernor.integration.t.sol
@@ -270,6 +270,68 @@ contract BasicCouncilVetoGovernorSmokeTest is BasicCouncilVetoGovernorTest {
     vm.prank(councilMembers[0]);
     vetoGovernor.cancel(targets, values, calldatas, keccak256(bytes("Overridden")));
   }
+
+  function testFuzz_ExecutionSucceedsWithPrefundedTimelock(uint256 _proposerIndex, uint256 _value)
+    public
+  {
+    vm.assume(_value > 0);
+    values[0] = _value;
+    calldatas[0] = abi.encodeWithSignature("depositExact(uint256)", _value);
+    uint256 _proposalId = _proposeAndForwardToVetoGovernor(_proposerIndex, "");
+
+    vm.warp(vetoGovernor.proposalDeadline(_proposalId) + 1);
+    vetoGovernor.queue(targets, values, calldatas, keccak256(bytes("")));
+    skip(timelock.getMinDelay());
+
+    vm.deal(address(timelock), _value);
+    vm.prank(councilMembers[0]);
+    councilGovernor.execute(targets, values, calldatas, keccak256(bytes("")));
+
+    assertEq(address(timelock).balance, 0);
+    assertEq(targets[0].balance, _value);
+  }
+
+  function testFuzz_ExecutionSucceedsWithCallerValue(uint256 _proposerIndex, uint256 _value)
+    public
+  {
+    vm.assume(_value > 0);
+    values[0] = _value;
+    calldatas[0] = abi.encodeWithSignature("depositExact(uint256)", _value);
+    uint256 _proposalId = _proposeAndForwardToVetoGovernor(_proposerIndex, "");
+
+    vm.warp(vetoGovernor.proposalDeadline(_proposalId) + 1);
+    vetoGovernor.queue(targets, values, calldatas, keccak256(bytes("")));
+    skip(timelock.getMinDelay());
+
+    vm.deal(councilMembers[0], _value);
+    vm.prank(councilMembers[0]);
+    councilGovernor.execute{value: _value}(targets, values, calldatas, keccak256(bytes("")));
+
+    assertEq(councilMembers[0].balance, 0);
+    assertEq(targets[0].balance, _value);
+  }
+
+  function testFuzz_ExecutionSucceedsWithSplitFunding(uint256 _proposerIndex, uint256 _callerValue)
+    public
+  {
+    vm.assume(0 < _callerValue && _callerValue < 1e18);
+    values[0] = 1e18;
+    calldatas[0] = abi.encodeWithSignature("deposit()");
+    uint256 _proposalId = _proposeAndForwardToVetoGovernor(_proposerIndex, "");
+
+    vm.warp(vetoGovernor.proposalDeadline(_proposalId) + 1);
+    vetoGovernor.queue(targets, values, calldatas, keccak256(bytes("")));
+    skip(timelock.getMinDelay());
+
+    vm.deal(councilMembers[0], _callerValue);
+    vm.deal(address(timelock), 1e18 - _callerValue);
+    vm.prank(councilMembers[0]);
+    councilGovernor.execute{value: _callerValue}(targets, values, calldatas, keccak256(bytes("")));
+
+    assertEq(councilMembers[0].balance, 0);
+    assertEq(address(timelock).balance, 0);
+    assertEq(targets[0].balance, 1e18);
+  }
 }
 
 contract _IsValidDescriptionForProposer is BasicCouncilVetoGovernorTest {

--- a/test/helpers/Counter.sol
+++ b/test/helpers/Counter.sol
@@ -11,4 +11,10 @@ contract Counter {
   function increment() public {
     number++;
   }
+
+  function deposit() public payable {}
+
+  function depositExact(uint256 amount) public payable {
+    require(msg.value == amount);
+  }
 }


### PR DESCRIPTION
- add explicit eth transfer in `GovernorCouncilQueuing._executeOperations`
- add tests